### PR TITLE
Support custom capture resolution in CamCapture

### DIFF
--- a/plugins/lcvcore/src/qcamcapture.h
+++ b/plugins/lcvcore/src/qcamcapture.h
@@ -24,9 +24,10 @@ class QCamCaptureThread;
 class QCamCapture : public QMatDisplay{
 
     Q_OBJECT
-    Q_PROPERTY(QString device READ device WRITE setDevice NOTIFY deviceChanged)
-    Q_PROPERTY(bool    paused READ paused WRITE setPaused NOTIFY pausedChanged)
-    Q_PROPERTY(qreal   fps    READ fps    WRITE setFps    NOTIFY fpsChanged)
+    Q_PROPERTY(QString device     READ device     WRITE setDevice     NOTIFY deviceChanged)
+    Q_PROPERTY(bool    paused     READ paused     WRITE setPaused     NOTIFY pausedChanged)
+    Q_PROPERTY(qreal   fps        READ fps        WRITE setFps        NOTIFY fpsChanged)
+    Q_PROPERTY(QSize   resolution READ resolution WRITE setResolution NOTIFY resolutionChanged)
 
 public:
     explicit QCamCapture(QQuickItem *parent = 0);
@@ -41,6 +42,9 @@ public:
     qreal fps() const;
     void setFps(qreal fps);
 
+    const QSize& resolution() const;
+    void setResolution(const QSize& resolution);
+
 public slots:
     void switchMat();
 
@@ -48,9 +52,11 @@ signals:
     void deviceChanged();
     void pausedChanged();
     void fpsChanged();
+    void resolutionChanged();
 
 private:
     void initializeMatSize();
+    void reinitializeDevice();
 
     QCamCapture(const QCamCapture& other);
     QCamCapture& operator= (const QCamCapture& other);
@@ -58,6 +64,7 @@ private:
     QString m_device;
     qreal   m_fps;
     QMat*   m_restore;
+    QSize   m_resolution;
 
     QCamCaptureThread* m_thread;
 
@@ -69,6 +76,10 @@ inline const QString &QCamCapture::device() const{
 
 inline qreal QCamCapture::fps() const{
     return m_fps;
+}
+
+inline const QSize& QCamCapture::resolution() const{
+    return m_resolution;
 }
 
 #endif // QCAMCAPTURE_HPP

--- a/plugins/lcvcore/src/qcamcapturethread.cpp
+++ b/plugins/lcvcore/src/qcamcapturethread.cpp
@@ -175,3 +175,15 @@ int QCamCaptureThread::captureHeight() const{
     Q_D(const QCamCaptureThread);
     return d->height;
 }
+
+// FRAME_WIDTH and FRAME_HEIGHT must be set together,
+// otherwise OpenCV may reject the change.
+void QCamCaptureThread::setCaptureResolution(int width, int height){
+    Q_D(QCamCaptureThread);
+    QMutexLocker lock(&d->mutex);
+    if ( d->capture->isOpened() ){
+        d->capture->set(CV_CAP_PROP_FRAME_WIDTH, width);
+        d->capture->set(CV_CAP_PROP_FRAME_HEIGHT, height);
+        initializeMatSize();
+    }
+}

--- a/plugins/lcvcore/src/qcamcapturethread.h
+++ b/plugins/lcvcore/src/qcamcapturethread.h
@@ -35,6 +35,7 @@ public:
     QTimer* timer();
     int     captureWidth() const;
     int     captureHeight() const;
+    void    setCaptureResolution(int width, int height);
     const QString& device() const;
 
     bool    isCaptureOpened();
@@ -43,7 +44,6 @@ public:
     void    setPaused(bool paused);
 
     void    processNextFrame();
-
 signals:
     void inactiveMatChanged();
 


### PR DESCRIPTION
This patch allows you to override the camera resolution to something other than the default (cameras often support multiple capture resolutions) like this:

```
import lcvcore 1.0

Rectangle{
    CamCapture{
        device: '0'
        width: 1280
        height: 720
    }
}
```

Not sure whether I did this right, played around a bit with different approaches and this seems to work well for me. I added the `reinitializeDevice` construction after I found that without starting a new capture there would sometimes be errors about the camera device being busy, effectively crashing the capture (probably some kind of race condition?).