### PR TITLE
Add background subtractors (#48 #49 #50)

### DIFF
--- a/plugins/lcvvideo/src/lcvvideo.pri
+++ b/plugins/lcvvideo/src/lcvvideo.pri
@@ -2,10 +2,12 @@ HEADERS += \
         $$PWD/lcvvideo_plugin.hpp \
     $$PWD/qcalcopticalflowpyrlk.h \
     $$PWD/qbackgroundsubtractormog.h \
-    $$PWD/qbackgroundsubtractor.h
+    $$PWD/qbackgroundsubtractor.h \
+    $$PWD/qbackgroundsubtractormog2.h
 
 SOURCES += \
     $$PWD/lcvvideo_plugin.cpp \
     $$PWD/qcalcopticalflowpyrlk.cpp \
     $$PWD/qbackgroundsubtractormog.cpp \
-    $$PWD/qbackgroundsubtractor.cpp
+    $$PWD/qbackgroundsubtractor.cpp \
+    $$PWD/qbackgroundsubtractormog2.cpp

--- a/plugins/lcvvideo/src/lcvvideo.pri
+++ b/plugins/lcvvideo/src/lcvvideo.pri
@@ -1,7 +1,11 @@
 HEADERS += \
         $$PWD/lcvvideo_plugin.hpp \
-    $$PWD/qcalcopticalflowpyrlk.h
+    $$PWD/qcalcopticalflowpyrlk.h \
+    $$PWD/qbackgroundsubtractormog.h \
+    $$PWD/qbackgroundsubtractor.h
 
 SOURCES += \
     $$PWD/lcvvideo_plugin.cpp \
-    $$PWD/qcalcopticalflowpyrlk.cpp
+    $$PWD/qcalcopticalflowpyrlk.cpp \
+    $$PWD/qbackgroundsubtractormog.cpp \
+    $$PWD/qbackgroundsubtractor.cpp

--- a/plugins/lcvvideo/src/lcvvideo_plugin.cpp
+++ b/plugins/lcvvideo/src/lcvvideo_plugin.cpp
@@ -18,10 +18,11 @@
 
 #include <qqml.h>
 #include "qcalcopticalflowpyrlk.h"
+#include "qbackgroundsubtractormog.h"
 
 void LcvvideoPlugin::registerTypes(const char *uri){
     // @uri modules.lcvvideo
-    qmlRegisterType<QCalcOpticalFlowPyrLK>( uri, 1, 0, "CalcOpticalFlowPyrLK");
+    qmlRegisterType<QCalcOpticalFlowPyrLK>(    uri, 1, 0, "CalcOpticalFlowPyrLK");
+    qmlRegisterType<QBackgroundSubtractor>(    uri, 1, 0, "BackgroundSubtractor");
+    qmlRegisterType<QBackgroundSubtractorMog>( uri, 1, 0, "BackgroundSubtractorMog");
 }
-
-

--- a/plugins/lcvvideo/src/lcvvideo_plugin.cpp
+++ b/plugins/lcvvideo/src/lcvvideo_plugin.cpp
@@ -19,10 +19,12 @@
 #include <qqml.h>
 #include "qcalcopticalflowpyrlk.h"
 #include "qbackgroundsubtractormog.h"
+#include "qbackgroundsubtractormog2.h"
 
 void LcvvideoPlugin::registerTypes(const char *uri){
     // @uri modules.lcvvideo
-    qmlRegisterType<QCalcOpticalFlowPyrLK>(    uri, 1, 0, "CalcOpticalFlowPyrLK");
-    qmlRegisterType<QBackgroundSubtractor>(    uri, 1, 0, "BackgroundSubtractor");
-    qmlRegisterType<QBackgroundSubtractorMog>( uri, 1, 0, "BackgroundSubtractorMog");
+    qmlRegisterType<QCalcOpticalFlowPyrLK>(     uri, 1, 0, "CalcOpticalFlowPyrLK");
+    qmlRegisterType<QBackgroundSubtractor>(     uri, 1, 0, "BackgroundSubtractor");
+    qmlRegisterType<QBackgroundSubtractorMog>(  uri, 1, 0, "BackgroundSubtractorMog");
+    qmlRegisterType<QBackgroundSubtractorMog2>( uri, 1, 0, "BackgroundSubtractorMog2");
 }

--- a/plugins/lcvvideo/src/qbackgroundsubtractor.cpp
+++ b/plugins/lcvvideo/src/qbackgroundsubtractor.cpp
@@ -1,0 +1,159 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#include "qbackgroundsubtractor.h"
+
+using namespace cv;
+
+// QBackgroundSubtractorPrivate Implementation
+// -------------------------------------------
+QBackgroundSubtractorPrivate::QBackgroundSubtractorPrivate()
+    : m_stateId("")
+    , m_learningRate(0){
+}
+
+QBackgroundSubtractorPrivate::~QBackgroundSubtractorPrivate(){
+}
+
+void QBackgroundSubtractorPrivate::deleteSubtractor(){
+    qWarning() << "QBackgroundSubtractorPrivate::deleteSubtractor MUST be overridden by a subclass!";
+}
+
+cv::BackgroundSubtractor* QBackgroundSubtractorPrivate::subtractor(){
+    qWarning() << "QBackgroundSubtractorPrivate::subtractor MUST be overridden by a subclass!";
+    return 0;
+}
+
+const QString& QBackgroundSubtractorPrivate::stateId() const{
+    return m_stateId;
+}
+
+void QBackgroundSubtractorPrivate::setStateId(const QString& id){
+    m_stateId = id;
+}
+
+double QBackgroundSubtractorPrivate::learningRate() const{
+    return m_learningRate;
+}
+
+void QBackgroundSubtractorPrivate::setLearningRate(double rate){
+    m_learningRate = rate;
+}
+
+// QBackgroundSubtractor Implementation
+// ------------------------------------
+
+/*!
+   \class QBackgroundSubtractor
+   \inmodule lcvvideo_cpp
+
+   Base class for background subtractor algorithms.
+   Should not be instantiated directly, use a specific background subtractor algorithm instead.
+ */
+
+/*!
+  \brief QBackgroundSubtractor constructor
+
+  Parameters:
+  \a d_ptr Private pointer of a subclass instance
+  \a parent
+ */
+QBackgroundSubtractor::QBackgroundSubtractor(QBackgroundSubtractorPrivate *d_ptr, QQuickItem *parent)
+    : QMatFilter(parent)
+    , d_ptr(d_ptr ? d_ptr : new QBackgroundSubtractorPrivate){
+    if ( !d_ptr ){
+        qWarning() << "QBackgroundSubtractor may not be initialized directly!"
+                   << "Instantiate a subclass instead.";
+    }
+}
+
+/*!
+  \brief QBackgroundSubtractor destructor
+ */
+QBackgroundSubtractor::~QBackgroundSubtractor(){
+}
+
+
+/*!
+  \fn void QBackgroundSubtractor::reset()
+  \sa BackgroundSubtractor::reset()
+ */
+
+/*!
+  \qmlmethod void BackgroundSubtractor::reset()
+
+  Resets the state (background model, history, ...) of the subtractor.
+ */
+void QBackgroundSubtractor::reset(){
+    Q_D(QBackgroundSubtractor);
+    d->deleteSubtractor();
+}
+
+/*!
+  \property QBackgroundSubtractor::stateId
+  \sa QBackgroundSubtractor::stateId
+ */
+
+/*!
+  \qmlproperty string QBackgroundSubtractor::stateId
+
+  This property is somehow required. It represents the id of the state container of this filter. The state is used in
+  order to store contents between compilations. Give this a unique id in order for the subtractor to not reset between compilations.
+ */
+const QString& QBackgroundSubtractor::stateId() const{
+    Q_D(const QBackgroundSubtractor);
+    return d->stateId();
+}
+
+void QBackgroundSubtractor::setStateId(const QString& id){
+    Q_D(QBackgroundSubtractor);
+    if ( d->stateId() != id ){
+        d->setStateId(id);
+        d->deleteSubtractor();
+        emit stateIdChanged();
+    }
+}
+
+/*!
+  \qmlproperty string QBackgroundSubtractor::learningRate
+
+  Learning rate for updating the background model (0 to 1, default is 0).
+ */
+double QBackgroundSubtractor::learningRate() const{
+    Q_D(const QBackgroundSubtractor);
+    return d->learningRate();
+}
+
+void QBackgroundSubtractor::setLearningRate(double rate){
+    Q_D(QBackgroundSubtractor);
+    if ( d->learningRate() != rate ){
+        d->setLearningRate(rate);
+        emit learningRateChanged();
+    }
+}
+
+/*!
+  \fn virtual void QBackgroundSubtractor::transform(cv::Mat& in, cv::Mat& out)
+  \brief Filtering function.
+
+  Parameters :
+  \a in
+  \a out
+ */
+void QBackgroundSubtractor::transform(Mat& in, Mat& out){
+    Q_D(QBackgroundSubtractor);
+    BackgroundSubtractor* subtractor = d->subtractor();
+    if (subtractor)
+        (*subtractor)(in, out, d->learningRate());
+}

--- a/plugins/lcvvideo/src/qbackgroundsubtractor.h
+++ b/plugins/lcvvideo/src/qbackgroundsubtractor.h
@@ -1,0 +1,79 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#ifndef QBACKGROUNDSUBTRACTOR_HPP
+#define QBACKGROUNDSUBTRACTOR_HPP
+
+#include <QQuickItem>
+#include "qmatfilter.h"
+#include "opencv2/video/background_segm.hpp"
+
+class QBackgroundSubtractorPrivate{
+
+public:
+    QBackgroundSubtractorPrivate();
+    virtual ~QBackgroundSubtractorPrivate();
+
+    virtual void deleteSubtractor();
+    virtual cv::BackgroundSubtractor* subtractor();
+
+    const QString& stateId() const;
+    void setStateId(const QString& id);
+
+    double learningRate() const;
+    void setLearningRate(double rate);
+
+private:
+    QString m_stateId;
+    double m_learningRate;
+
+};
+
+class QBackgroundSubtractor : public QMatFilter{
+
+    Q_OBJECT
+    Q_PROPERTY(QString stateId      READ stateId      WRITE setStateId      NOTIFY stateIdChanged)
+    Q_PROPERTY(double  learningRate READ learningRate WRITE setLearningRate NOTIFY learningRateChanged)
+
+public:
+    explicit QBackgroundSubtractor(QBackgroundSubtractorPrivate *d_ptr = 0, QQuickItem *parent = 0);
+    virtual ~QBackgroundSubtractor();
+
+    const QString& stateId() const;
+    void setStateId(const QString& id);
+
+    double learningRate() const;
+    void setLearningRate(double rate);
+
+    virtual void transform(cv::Mat& in, cv::Mat& out);
+
+public slots:
+    void reset();
+
+signals:
+    void stateIdChanged();
+    void learningRateChanged();
+
+protected:
+    QBackgroundSubtractorPrivate* const d_ptr;
+
+private:
+    QBackgroundSubtractor(const QBackgroundSubtractor& other);
+    QBackgroundSubtractor& operator= (const QBackgroundSubtractor& other);
+
+    Q_DECLARE_PRIVATE(QBackgroundSubtractor)
+
+};
+
+#endif // QBACKGROUNDSUBTRACTOR_HPP

--- a/plugins/lcvvideo/src/qbackgroundsubtractormog.cpp
+++ b/plugins/lcvvideo/src/qbackgroundsubtractormog.cpp
@@ -1,0 +1,232 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#include "qbackgroundsubtractormog.h"
+#include "qstatecontainer.h"
+
+using namespace cv;
+
+/*!
+  \qmltype BackgroundSubtractorMog
+  \instantiates QBackgroundSubtractorMog
+  \inqmlmodule lcvvideo
+  \inherits MatFilter
+  \brief Background subtractor
+
+  Background subtractor
+*/
+
+class QBackgroundSubtractorMogPrivate : public QBackgroundSubtractorPrivate{
+
+public:
+    QBackgroundSubtractorMogPrivate();
+    virtual ~QBackgroundSubtractorMogPrivate();
+
+    virtual void deleteSubtractor();
+    virtual BackgroundSubtractor* subtractor();
+
+    BackgroundSubtractorMOG* subtractorMog();
+
+public:
+    int history;
+    int nmixtures;
+    double backgroundRatio;
+    double noiseSigma;
+
+private:
+    BackgroundSubtractorMOG* createSubtractor();
+
+private:
+    BackgroundSubtractorMOG* m_subtractorMog;
+
+};
+
+// QBackgroundSubtractorMogPrivate Implementation
+// -------------------------------------------
+QBackgroundSubtractorMogPrivate::QBackgroundSubtractorMogPrivate()
+    : QBackgroundSubtractorPrivate()
+    , history(20)
+    , nmixtures(5)
+    , backgroundRatio(0.7)
+    , noiseSigma(15)
+    , m_subtractorMog(0){
+}
+
+QBackgroundSubtractorMogPrivate::~QBackgroundSubtractorMogPrivate(){
+    if ( stateId() == "" ) // otherwise leave it to the QStateContiner
+        delete m_subtractorMog;
+}
+
+BackgroundSubtractorMOG* QBackgroundSubtractorMogPrivate::createSubtractor(){
+    return new BackgroundSubtractorMOG(history, nmixtures, backgroundRatio, noiseSigma);
+}
+
+void QBackgroundSubtractorMogPrivate::deleteSubtractor(){
+    QStateContainer<BackgroundSubtractorMOG>& stateCont =
+            QStateContainer<BackgroundSubtractorMOG>::instance();
+    stateCont.registerState(stateId(), static_cast<BackgroundSubtractorMOG*>(0));
+    delete m_subtractorMog;
+    m_subtractorMog = 0;
+}
+
+BackgroundSubtractorMOG* QBackgroundSubtractorMogPrivate::subtractorMog(){
+    if ( !m_subtractorMog ){
+        if ( stateId() != "" ){
+            QStateContainer<BackgroundSubtractorMOG>& stateCont =
+                    QStateContainer<BackgroundSubtractorMOG>::instance();
+
+            m_subtractorMog = stateCont.state(stateId());
+            if ( m_subtractorMog == 0 ){
+                m_subtractorMog = createSubtractor();
+                stateCont.registerState(stateId(), m_subtractorMog);
+            }
+        } else {
+            qWarning("QBackgroundSubtractorMog does not have a stateId assigned and cannot save "
+                     "it\'s state over multiple compilations. Set a unique stateId to "
+                     "avoid this problem.");
+            m_subtractorMog = createSubtractor();
+        }
+    }
+    return m_subtractorMog;
+}
+
+BackgroundSubtractor* QBackgroundSubtractorMogPrivate::subtractor(){
+    return subtractorMog();
+}
+
+// QBackgroundSubtractorMog Implementation
+// ------------------------------------
+
+/*!
+   \class QBackgroundSubtractorMog
+   \inmodule lcvvideo_cpp
+   \brief Subtracts background using MOG algorithm.
+ */
+
+/*!
+  \brief QBackgroundSubtractorMog constructor
+
+  Parameters:
+  \a parent
+ */
+QBackgroundSubtractorMog::QBackgroundSubtractorMog(QQuickItem *parent)
+    : QBackgroundSubtractor(new QBackgroundSubtractorMogPrivate, parent)
+    , d_ptr(static_cast<QBackgroundSubtractorMogPrivate*>(QBackgroundSubtractor::d_ptr)){
+}
+
+/*!
+  \brief QBackgroundSubtractorMog destructor
+ */
+QBackgroundSubtractorMog::~QBackgroundSubtractorMog(){
+}
+
+/*!
+  \property QBackgroundSubtractorMog::history
+  \sa BackgroundSubtractorMog::history
+ */
+
+/*!
+  \qmlproperty int BackgroundSubtractorMog::history
+
+  Length of the history. Defaults to 20.
+ */
+int QBackgroundSubtractorMog::history() const{
+    Q_D(const QBackgroundSubtractorMog);
+    return d->history;
+}
+
+void QBackgroundSubtractorMog::setHistory(int history){
+    Q_D(QBackgroundSubtractorMog);
+    if ( d->history != history ){
+         d->history = history;
+         if ( d->subtractorMog() )
+            d->subtractorMog()->setInt("history", history);
+         emit historyChanged();
+    }
+}
+
+/*!
+  \property QBackgroundSubtractorMog::nmixtures
+  \sa BackgroundSubtractorMog::nmixtures
+ */
+
+/*!
+  \qmlproperty int BackgroundSubtractorMog::nmixtures
+
+  Number of Gaussian mixtures. Defaults to 5.
+ */
+int QBackgroundSubtractorMog::nmixtures() const{
+    Q_D(const QBackgroundSubtractorMog);
+    return d->nmixtures;
+}
+
+void QBackgroundSubtractorMog::setNmixtures(int nmixtures){
+    Q_D(QBackgroundSubtractorMog);
+    if ( d->nmixtures != nmixtures ){
+         d->nmixtures = nmixtures;
+         if ( d->subtractorMog() )
+            d->subtractorMog()->setInt("nmixtures", nmixtures);
+         emit nmixturesChanged();
+    }
+}
+
+/*!
+  \property QBackgroundSubtractorMog::backgroundRatio
+  \sa BackgroundSubtractorMog::backgroundRatio
+ */
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog::backgroundRatio
+
+  Background ratio. Defaults to 0.7.
+ */
+double QBackgroundSubtractorMog::backgroundRatio() const{
+    Q_D(const QBackgroundSubtractorMog);
+    return d->backgroundRatio;
+}
+
+void QBackgroundSubtractorMog::setBackgroundRatio(double backgroundRatio){
+    Q_D(QBackgroundSubtractorMog);
+    if ( d->backgroundRatio != backgroundRatio ){
+         d->backgroundRatio = backgroundRatio;
+         if ( d->subtractorMog() )
+            d->subtractorMog()->setDouble("backgroundRatio", backgroundRatio);
+         emit backgroundRatioChanged();
+    }
+}
+
+/*!
+  \property QBackgroundSubtractorMog::noiseSigma
+  \sa BackgroundSubtractorMog::noiseSigma
+ */
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog::noiseSigma
+
+  Noise strength. Defaults to 15.
+ */
+double QBackgroundSubtractorMog::noiseSigma() const{
+    Q_D(const QBackgroundSubtractorMog);
+    return d->noiseSigma;
+}
+
+void QBackgroundSubtractorMog::setNoiseSigma(double noiseSigma){
+    Q_D(QBackgroundSubtractorMog);
+    if ( d->noiseSigma != noiseSigma ){
+         d->noiseSigma = noiseSigma;
+         if ( d->subtractorMog() )
+            d->subtractorMog()->setDouble("noiseSigma", noiseSigma);
+         emit noiseSigmaChanged();
+    }
+}

--- a/plugins/lcvvideo/src/qbackgroundsubtractormog.h
+++ b/plugins/lcvvideo/src/qbackgroundsubtractormog.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#ifndef QBACKGROUNDSUBTRACTORMOG_HPP
+#define QBACKGROUNDSUBTRACTORMOG_HPP
+
+#include <QQuickItem>
+#include "qbackgroundsubtractor.h"
+
+class QBackgroundSubtractorMogPrivate;
+
+class QBackgroundSubtractorMog : public QBackgroundSubtractor{
+
+    Q_OBJECT
+    Q_PROPERTY(int    history         READ history         WRITE setHistory         NOTIFY historyChanged)
+    Q_PROPERTY(int    nmixtures       READ nmixtures       WRITE setNmixtures       NOTIFY nmixturesChanged)
+    Q_PROPERTY(double backgroundRatio READ backgroundRatio WRITE setBackgroundRatio NOTIFY backgroundRatioChanged)
+    Q_PROPERTY(double noiseSigma      READ noiseSigma      WRITE setNoiseSigma      NOTIFY noiseSigmaChanged)
+
+public:
+    explicit QBackgroundSubtractorMog(QQuickItem *parent = 0);
+    virtual ~QBackgroundSubtractorMog();
+
+    int history() const;
+    void setHistory(int history);
+
+    int nmixtures() const;
+    void setNmixtures(int nmixtures);
+
+    double backgroundRatio() const;
+    void setBackgroundRatio(double backgroundRatio);
+
+    double noiseSigma() const;
+    void setNoiseSigma(double noiseSigma);
+
+signals:
+    void historyChanged();
+    void nmixturesChanged();
+    void backgroundRatioChanged();
+    void noiseSigmaChanged();
+
+private:
+    QBackgroundSubtractorMog(const QBackgroundSubtractorMog& other);
+    QBackgroundSubtractorMog& operator= (const QBackgroundSubtractorMog& other);
+
+    QBackgroundSubtractorMogPrivate* const d_ptr;
+
+    Q_DECLARE_PRIVATE(QBackgroundSubtractorMog)
+
+};
+
+#endif // QBACKGROUNDSUBTRACTORMOG_HPP

--- a/plugins/lcvvideo/src/qbackgroundsubtractormog2.cpp
+++ b/plugins/lcvvideo/src/qbackgroundsubtractormog2.cpp
@@ -1,0 +1,436 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#include "qbackgroundsubtractormog2.h"
+#include "qstatecontainer.h"
+
+using namespace cv;
+
+/*!
+  \qmltype BackgroundSubtractorMOG2
+  \instantiates QBackgroundSubtractorMog2
+  \inqmlmodule lcvvideo
+  \inherits MatFilter
+  \brief Background subtractor
+
+  Background subtractor
+*/
+
+class QBackgroundSubtractorMog2Private : public QBackgroundSubtractorPrivate{
+
+public:
+    QBackgroundSubtractorMog2Private();
+    virtual ~QBackgroundSubtractorMog2Private();
+
+    virtual void deleteSubtractor();
+    virtual BackgroundSubtractor* subtractor();
+
+    BackgroundSubtractorMOG2* subtractorMog2();
+
+public:
+    int history;
+    int nmixtures;
+    uchar nShadowDetection;
+    bool detectShadows;
+    float backgroundRatio;
+    float ct;
+    float tau;
+    float varInit;
+    float varMin;
+    float varMax;
+    float varThreshold;
+    float varThresholdGen;
+
+private:
+    BackgroundSubtractorMOG2* createSubtractor();
+
+private:
+    BackgroundSubtractorMOG2* m_subtractorMog2;
+
+};
+
+// QBackgroundSubtractorMog2Private Implementation
+// -------------------------------------------
+QBackgroundSubtractorMog2Private::QBackgroundSubtractorMog2Private()
+    : QBackgroundSubtractorPrivate()
+    , history(500)
+    , nmixtures(5)
+    , nShadowDetection(127)
+    , detectShadows(false)
+    , backgroundRatio(0.9)
+    , ct(0.05)
+    , tau(0.5)
+    , varInit(15)
+    , varMin(4)
+    , varMax(75)
+    , varThreshold(16)
+    , varThresholdGen(9)
+    , m_subtractorMog2(0){
+}
+
+QBackgroundSubtractorMog2Private::~QBackgroundSubtractorMog2Private(){
+    if ( stateId() == "" ) // otherwise leave it to the QStateContiner
+        delete m_subtractorMog2;
+}
+
+BackgroundSubtractorMOG2* QBackgroundSubtractorMog2Private::createSubtractor(){
+    BackgroundSubtractorMOG2* subtractor = new BackgroundSubtractorMOG2(history, varThreshold, detectShadows);
+    subtractor->setInt("nmixtures", nmixtures);
+    subtractor->set("nShadowDetection", static_cast<uchar>(nShadowDetection));
+    subtractor->set("backgroundRatio", backgroundRatio);
+    subtractor->set("fCT", ct);
+    subtractor->set("fTau", tau);
+    subtractor->set("fVarInit", varInit);
+    subtractor->set("fVarMin", varMin);
+    subtractor->set("fVarMax", varMax);
+    subtractor->set("varThresholdGen", varThresholdGen);
+    return subtractor;
+}
+
+void QBackgroundSubtractorMog2Private::deleteSubtractor(){
+    QStateContainer<BackgroundSubtractorMOG2>& stateCont =
+            QStateContainer<BackgroundSubtractorMOG2>::instance();
+    stateCont.registerState(stateId(), static_cast<BackgroundSubtractorMOG2*>(0));
+    delete m_subtractorMog2;
+    m_subtractorMog2 = 0;
+}
+
+BackgroundSubtractorMOG2* QBackgroundSubtractorMog2Private::subtractorMog2(){
+    if ( !m_subtractorMog2 ){
+        if ( stateId() != "" ){
+            QStateContainer<BackgroundSubtractorMOG2>& stateCont =
+                    QStateContainer<BackgroundSubtractorMOG2>::instance();
+
+            m_subtractorMog2 = stateCont.state(stateId());
+            if ( m_subtractorMog2 == 0 ){
+                m_subtractorMog2 = createSubtractor();
+                stateCont.registerState(stateId(), m_subtractorMog2);
+            }
+        } else {
+            qWarning("QBackgroundSubtractorMog2 does not have a stateId assigned and cannot save "
+                     "it\'s state over multiple compilations. Set a unique stateId to "
+                     "avoid this problem.");
+            m_subtractorMog2 = createSubtractor();
+        }
+    }
+    return m_subtractorMog2;
+}
+
+BackgroundSubtractor* QBackgroundSubtractorMog2Private::subtractor(){
+    return subtractorMog2();
+}
+
+// QBackgroundSubtractorMog2 Implementation
+// ------------------------------------
+
+/*!
+   \class QBackgroundSubtractorMog2
+   \inmodule lcvvideo_cpp
+   \brief Subtracts background using Mog2 algorithm.
+ */
+
+/*!
+  \brief QBackgroundSubtractorMog2 constructor
+
+  Parameters:
+  \a parent
+ */
+QBackgroundSubtractorMog2::QBackgroundSubtractorMog2(QQuickItem *parent)
+    : QBackgroundSubtractor(new QBackgroundSubtractorMog2Private, parent)
+    , d_ptr(static_cast<QBackgroundSubtractorMog2Private*>(QBackgroundSubtractor::d_ptr)){
+}
+
+/*!
+  \brief QBackgroundSubtractorMog2 destructor
+ */
+QBackgroundSubtractorMog2::~QBackgroundSubtractorMog2(){
+}
+
+/*!
+  \property QBackgroundSubtractorMog2::history
+  \sa BackgroundSubtractorMog2::history
+ */
+
+/*!
+  \qmlproperty int BackgroundSubtractorMog2::history
+
+  Length of the history. Defaults to 500.
+ */
+int QBackgroundSubtractorMog2::history() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->history;
+}
+
+void QBackgroundSubtractorMog2::setHistory(int history){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->history != history ){
+         d->history = history;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->setInt("history", history);
+         emit historyChanged();
+    }
+}
+
+/*!
+  \property QBackgroundSubtractorMog2::nmixtures
+  \sa BackgroundSubtractorMog2::nmixtures
+ */
+
+/*!
+  \qmlproperty int BackgroundSubtractorMog2::nmixtures
+
+  Maximum allowed number of mixture components. Defaults to 5.
+ */
+int QBackgroundSubtractorMog2::nmixtures() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->nmixtures;
+}
+
+void QBackgroundSubtractorMog2::setNmixtures(int nmixtures){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->nmixtures != nmixtures ){
+         d->nmixtures = nmixtures;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->setInt("nmixtures", nmixtures);
+         emit nmixturesChanged();
+    }
+}
+
+/*!
+  \property QBackgroundSubtractorMog2::nShadowDetection
+  \sa BackgroundSubtractorMog2::nShadowDetection
+ */
+
+/*!
+  \qmlproperty int BackgroundSubtractorMog2::nShadowDetection
+
+  The value for marking shadow pixels in the output foreground mask.
+  Must be in the range 0-255. Defaults to 127.
+ */
+int QBackgroundSubtractorMog2::nShadowDetection() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->nShadowDetection;
+}
+
+void QBackgroundSubtractorMog2::setNShadowDetection(int nShadowDetection){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( nShadowDetection > 255 )
+        nShadowDetection = 255;
+    if ( nShadowDetection < 0 )
+        nShadowDetection = 0;
+    if ( d->nShadowDetection != nShadowDetection ){
+         d->nShadowDetection = nShadowDetection;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("nShadowDetection", static_cast<uchar>(nShadowDetection));
+         emit nShadowDetectionChanged();
+    }
+}
+
+/*!
+  \property QBackgroundSubtractorMog2::detectShadows
+  \sa BackgroundSubtractorMog2::detectShadows
+ */
+
+/*!
+  \qmlproperty bool BackgroundSubtractorMog2::detectShadows
+
+  Whether shadow detection should be enabled. Defaults to false.
+ */
+bool QBackgroundSubtractorMog2::detectShadows() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->detectShadows;
+}
+
+void QBackgroundSubtractorMog2::setDetectShadows(bool detectShadows){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->detectShadows != detectShadows ){
+         d->detectShadows = detectShadows;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->setBool("detectShadows", detectShadows);
+         emit detectShadowsChanged();
+    }
+}
+
+/*!
+  \property QBackgroundSubtractorMog2::backgroundRatio
+  \sa BackgroundSubtractorMog2::backgroundRatio
+ */
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog2::backgroundRatio
+
+  Threshold defining whether the component is significant enough to be included into the background model.
+  Defaults to 0.9.
+ */
+float QBackgroundSubtractorMog2::backgroundRatio() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->backgroundRatio;
+}
+
+void QBackgroundSubtractorMog2::setBackgroundRatio(float backgroundRatio){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->backgroundRatio != backgroundRatio ){
+         d->backgroundRatio = backgroundRatio;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("backgroundRatio", backgroundRatio);
+         emit backgroundRatioChanged();
+    }
+}
+
+/*!
+  \property QBackgroundSubtractorMog2::ct
+  \sa BackgroundSubtractorMog2::ct
+ */
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog2::ct
+
+  Complexity reduction parameter. Defaults to 0.05.
+ */
+float QBackgroundSubtractorMog2::ct() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->ct;
+}
+
+void QBackgroundSubtractorMog2::setCt(float ct){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->ct != ct ){
+         d->ct = ct;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("fCT", ct);
+         emit ctChanged();
+    }
+}
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog2::tau
+
+  Shadow threshold. Defaults to 0.5.
+ */
+float QBackgroundSubtractorMog2::tau() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->tau;
+}
+
+void QBackgroundSubtractorMog2::setTau(float tau){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->tau != tau ){
+         d->tau = tau;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("fTau", tau);
+         emit tauChanged();
+    }
+}
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog2::varInit
+
+  Initial variance for the newly generated components. Defaults to 15.
+ */
+float QBackgroundSubtractorMog2::varInit() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->varInit;
+}
+
+void QBackgroundSubtractorMog2::setVarInit(float varInit){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->varInit != varInit ){
+         d->varInit = varInit;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("fVarInit", varInit);
+         emit varInitChanged();
+    }
+}
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog2::varMin
+
+  Parameter used to further control the variance. Defaults to 4.
+ */
+float QBackgroundSubtractorMog2::varMin() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->varMin;
+}
+
+void QBackgroundSubtractorMog2::setVarMin(float varMin){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->varMin != varMin ){
+         d->varMin = varMin;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("fVarMin", varMin);
+         emit varMinChanged();
+    }
+}
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog2::varMax
+
+  Parameter used to further control the variance. Defaults to 75.
+ */
+float QBackgroundSubtractorMog2::varMax() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->varMax;
+}
+
+void QBackgroundSubtractorMog2::setVarMax(float varMax){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->varMax != varMax ){
+         d->varMax = varMax;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("fVarMax", varMax);
+         emit varMaxChanged();
+    }
+}
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog2::varThreshold
+
+  Threshold on the squared Mahalanobis distance to decide whether it is well described by the background model.
+  Defaults to 16.
+ */
+float QBackgroundSubtractorMog2::varThreshold() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->varThreshold;
+}
+
+void QBackgroundSubtractorMog2::setVarThreshold(float varThreshold){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->varThreshold != varThreshold ){
+         d->varThreshold = varThreshold;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("varThreshold", varThreshold);
+         emit varThresholdChanged();
+    }
+}
+
+/*!
+  \qmlproperty double BackgroundSubtractorMog2::varThresholdGen
+
+  Threshold for the squared Mahalanobis distance that helps decide when a sample is close to the existing components.
+  Defaults to 9.
+ */
+float QBackgroundSubtractorMog2::varThresholdGen() const{
+    Q_D(const QBackgroundSubtractorMog2);
+    return d->varThresholdGen;
+}
+
+void QBackgroundSubtractorMog2::setVarThresholdGen(float varThresholdGen){
+    Q_D(QBackgroundSubtractorMog2);
+    if ( d->varThresholdGen != varThresholdGen ){
+         d->varThresholdGen = varThresholdGen;
+         if ( d->subtractorMog2() )
+            d->subtractorMog2()->set("varThresholdGen", varThresholdGen);
+         emit varThresholdGenChanged();
+    }
+}

--- a/plugins/lcvvideo/src/qbackgroundsubtractormog2.h
+++ b/plugins/lcvvideo/src/qbackgroundsubtractormog2.h
@@ -1,0 +1,103 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#ifndef QBACKGROUNDSUBTRACTORMOG2_HPP
+#define QBACKGROUNDSUBTRACTORMOG2_HPP
+
+#include <QQuickItem>
+#include "qbackgroundsubtractor.h"
+
+class QBackgroundSubtractorMog2Private;
+
+class QBackgroundSubtractorMog2 : public QBackgroundSubtractor{
+
+    Q_OBJECT
+    Q_PROPERTY(int   history          READ history          WRITE setHistory          NOTIFY historyChanged)
+    Q_PROPERTY(int   nmixtures        READ nmixtures        WRITE setNmixtures        NOTIFY nmixturesChanged)
+    Q_PROPERTY(int   nShadowDetection READ nShadowDetection WRITE setNShadowDetection NOTIFY nShadowDetectionChanged)
+    Q_PROPERTY(bool  detectShadows    READ detectShadows    WRITE setDetectShadows    NOTIFY detectShadowsChanged)
+    Q_PROPERTY(float backgroundRatio  READ backgroundRatio  WRITE setBackgroundRatio  NOTIFY backgroundRatioChanged)
+    Q_PROPERTY(float ct               READ ct               WRITE setCt               NOTIFY ctChanged)
+    Q_PROPERTY(float tau              READ tau              WRITE setTau              NOTIFY tauChanged)
+    Q_PROPERTY(float varInit          READ varInit          WRITE setVarInit          NOTIFY varInitChanged)
+    Q_PROPERTY(float varMin           READ varMin           WRITE setVarMin           NOTIFY varMinChanged)
+    Q_PROPERTY(float varMax           READ varMax           WRITE setVarMax           NOTIFY varMaxChanged)
+    Q_PROPERTY(float varThreshold     READ varThreshold     WRITE setVarThreshold     NOTIFY varThresholdChanged)
+    Q_PROPERTY(float varThresholdGen  READ varThresholdGen  WRITE setVarThresholdGen  NOTIFY varThresholdGenChanged)
+
+public:
+    explicit QBackgroundSubtractorMog2(QQuickItem *parent = 0);
+    virtual ~QBackgroundSubtractorMog2();
+
+    int history() const;
+    void setHistory(int history);
+
+    int nmixtures() const;
+    void setNmixtures(int nmixtures);
+
+    int nShadowDetection() const;
+    void setNShadowDetection(int nShadowDetection);
+
+    bool detectShadows() const;
+    void setDetectShadows(bool detectShadows);
+
+    float backgroundRatio() const;
+    void setBackgroundRatio(float backgroundRatio);
+
+    float ct() const;
+    void setCt(float ct);
+
+    float tau() const;
+    void setTau(float tau);
+
+    float varInit() const;
+    void setVarInit(float varInit);
+
+    float varMin() const;
+    void setVarMin(float varMin);
+
+    float varMax() const;
+    void setVarMax(float varMax);
+
+    float varThreshold() const;
+    void setVarThreshold(float varThreshold);
+
+    float varThresholdGen() const;
+    void setVarThresholdGen(float varThresholdGen);
+
+signals:
+    void historyChanged();
+    void nmixturesChanged();
+    void nShadowDetectionChanged();
+    void detectShadowsChanged();
+    void backgroundRatioChanged();
+    void ctChanged();
+    void tauChanged();
+    void varInitChanged();
+    void varMinChanged();
+    void varMaxChanged();
+    void varThresholdChanged();
+    void varThresholdGenChanged();
+
+private:
+    QBackgroundSubtractorMog2(const QBackgroundSubtractorMog2& other);
+    QBackgroundSubtractorMog2& operator= (const QBackgroundSubtractorMog2& other);
+
+    QBackgroundSubtractorMog2Private* const d_ptr;
+
+    Q_DECLARE_PRIVATE(QBackgroundSubtractorMog2)
+
+};
+
+#endif // QBACKGROUNDSUBTRACTORMOG2_HPP


### PR DESCRIPTION
This is what I came up with: a base class public/private pair holding all shared properties/methods and doing the actual filtering, and a child class public/private pair containing only the algorithm-specific stuff.

The base class is abstract though (which makes sense to me since it can't actually do anything by itself), making it impossible to register it as a QML type. Not personally a problem for me but you mentioned something about wanting it to be a QML type. Thoughts?

This PR is not intended for merging yet, wanted to get feedback before also implementing the other algorithms (BackgroundSubtractorMOG2 and possibly BackgroundSubtractorGMG. The latter is not in livecv issues or opencv 2.4.13 doxygen, but it is present in my opencv 2.4.13 source tree / public headers and the opencv3 doxygen. Not sure what the status of this one is in 2.4.)
