### PR TITLE
New plugin: lcvphoto

### DIFF
--- a/doc/qdoc/page_cpp_modules.qdoc
+++ b/doc/qdoc/page_cpp_modules.qdoc
@@ -17,6 +17,9 @@
     \row
         \li \l {lcvvideo_cpp}{video}
         \li The lcvvideo module.
+    \row
+        \li \l {lcvphoto_cpp}{photo}
+        \li The lcvphoto module.
 \endtable
 
 */

--- a/doc/qdoc/page_index.qdoc
+++ b/doc/qdoc/page_index.qdoc
@@ -31,6 +31,9 @@
     \row
         \li \l {lcvvideo}{lcvvideo}
         \li Video processing module.
+    \row
+        \li \l {lcvphoto}{lcvphoto}
+        \li Computational photography module.
 \endtable
 
 
@@ -72,6 +75,9 @@
     \row
         \li \l {lcvvideo_cpp}{video}
         \li The lcvvideo module.
+    \row
+        \li \l {lcvphoto_cpp}{photo}
+        \li The lcvphoto module.
 \endtable
 
 

--- a/doc/qdoc/page_qml_modules.qdoc
+++ b/doc/qdoc/page_qml_modules.qdoc
@@ -14,6 +14,9 @@
     \row
         \li \l {lcvvideo}{lcvvideo}
         \li Video processing module.
+    \row
+        \li \l {lcvphoto}{lcvphoto}
+        \li Computational photography module.
 \endtable
 
 */

--- a/plugins/lcvphoto/.gitignore
+++ b/plugins/lcvphoto/.gitignore
@@ -1,0 +1,1 @@
+lcvphoto.pro.user

--- a/plugins/lcvphoto/doc/lcvphoto.qdoc
+++ b/plugins/lcvphoto/doc/lcvphoto.qdoc
@@ -1,0 +1,13 @@
+/*!
+
+  \qmlmodule lcvphoto
+
+  \title Live CV QML Computational Photography
+
+  This module contains elements for photo processing. It resembles open cv's photo module.
+
+  \code
+  import "lcvphoto" 1.0
+  \endcode
+
+*/

--- a/plugins/lcvphoto/doc/lcvphoto_cpp.qdoc
+++ b/plugins/lcvphoto/doc/lcvphoto_cpp.qdoc
@@ -1,0 +1,11 @@
+/*!
+
+  \module lcvphoto_cpp
+
+  \title Live CV Computational Photography
+
+  \brief This module contains the cpp implementation of the photo processing elements from Live CV.
+
+  \sa lcvcore
+
+*/

--- a/plugins/lcvphoto/lcvphoto.pro
+++ b/plugins/lcvphoto/lcvphoto.pro
@@ -1,0 +1,45 @@
+TEMPLATE = lib
+TARGET   = lcvphoto
+QT      += qml quick
+CONFIG  += qt plugin
+
+TARGET = $$qtLibraryTarget($$TARGET)
+uri = plugins.lcvcore
+
+OTHER_FILES = qmldir
+
+DEFINES += Q_LCV
+
+include($$PWD/src/lcvphoto.pri)
+include($$PWD/../../3rdparty/opencvconfig.pro)
+loadOpenCV(core highgui photo, deploy)
+
+INCLUDEPATH += $$PWD/../../lib/include
+DEPENDPATH  += $$PWD/../../lib/include
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../lib/release/ -llcvlib
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../lib/debug/ -llcvlib
+else:unix: LIBS += -L$$OUT_PWD/../../application/ -llcvlib
+
+# Destination
+
+win32:CONFIG(debug, debug|release): DESTDIR = $$quote($$OUT_PWD/../../application/debug/plugins/lcvphoto)
+else:win32:CONFIG(release, debug|release): DESTDIR = $$quote($$OUT_PWD/../../application/release/plugins/lcvphoto)
+else:unix: DESTDIR = $$quote($$OUT_PWD/../../application/plugins/lcvphoto)
+
+
+!equals(_PRO_FILE_PWD_, $$OUT_PWD) {
+    copy_qmldir.target = $$DESTDIR/qmldir
+    copy_qmldir.depends = $$_PRO_FILE_PWD_/qmldir
+    copy_qmldir.commands = $(COPY_FILE) \"$$replace(copy_qmldir.depends, /, $$QMAKE_DIR_SEP)\" \"$$replace(copy_qmldir.target, /, $$QMAKE_DIR_SEP)\"
+    QMAKE_EXTRA_TARGETS += copy_qmldir
+    PRE_TARGETDEPS += $$copy_qmldir.target
+}
+
+qmldir.files = qmldir
+unix {
+    installPath = $$[QT_INSTALL_QML]/$$replace(uri, \\., /)
+    qmldir.path = $$installPath
+    target.path = $$installPath
+    INSTALLS += target qmldir
+}

--- a/plugins/lcvphoto/qmldir
+++ b/plugins/lcvphoto/qmldir
@@ -1,0 +1,3 @@
+module lcvphoto
+plugin lcvphoto
+

--- a/plugins/lcvphoto/src/lcvphoto.pri
+++ b/plugins/lcvphoto/src/lcvphoto.pri
@@ -1,0 +1,7 @@
+HEADERS += \
+        $$PWD/lcvphoto_plugin.h \
+    $$PWD/qfastnlmeansdenoising.h
+
+SOURCES += \
+        $$PWD/lcvphoto_plugin.cpp \
+    $$PWD/qfastnlmeansdenoising.cpp

--- a/plugins/lcvphoto/src/lcvphoto.pri
+++ b/plugins/lcvphoto/src/lcvphoto.pri
@@ -1,7 +1,9 @@
 HEADERS += \
         $$PWD/lcvphoto_plugin.h \
-    $$PWD/qfastnlmeansdenoising.h
+    $$PWD/qfastnlmeansdenoising.h \
+    $$PWD/qfastnlmeansdenoisingmulti.h
 
 SOURCES += \
         $$PWD/lcvphoto_plugin.cpp \
-    $$PWD/qfastnlmeansdenoising.cpp
+    $$PWD/qfastnlmeansdenoising.cpp \
+    $$PWD/qfastnlmeansdenoisingmulti.cpp

--- a/plugins/lcvphoto/src/lcvphoto_plugin.cpp
+++ b/plugins/lcvphoto/src/lcvphoto_plugin.cpp
@@ -1,0 +1,25 @@
+/****************************************************************************
+**
+** Copyright (C) 2014-2016 Dinu SV.
+** (contact: mail@dinusv.com)
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#include "lcvphoto_plugin.h"
+
+#include <qqml.h>
+#include "qfastnlmeansdenoising.h"
+
+void LcvphotoPlugin::registerTypes(const char *uri){
+    // @uri modules.lcvphoto
+    qmlRegisterType<QFastNlMeansDenoising>(uri, 1, 0, "FastNlMeansDenoising");
+}

--- a/plugins/lcvphoto/src/lcvphoto_plugin.cpp
+++ b/plugins/lcvphoto/src/lcvphoto_plugin.cpp
@@ -17,9 +17,10 @@
 #include "lcvphoto_plugin.h"
 
 #include <qqml.h>
-#include "qfastnlmeansdenoising.h"
+#include "qfastnlmeansdenoisingmulti.h"
 
 void LcvphotoPlugin::registerTypes(const char *uri){
     // @uri modules.lcvphoto
-    qmlRegisterType<QFastNlMeansDenoising>(uri, 1, 0, "FastNlMeansDenoising");
+    qmlRegisterType<QFastNlMeansDenoising>     (uri, 1, 0, "FastNlMeansDenoising");
+    qmlRegisterType<QFastNlMeansDenoisingMulti>(uri, 1, 0, "FastNlMeansDenoisingMulti");
 }

--- a/plugins/lcvphoto/src/lcvphoto_plugin.h
+++ b/plugins/lcvphoto/src/lcvphoto_plugin.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+**
+** Copyright (C) 2014-2016 Dinu SV.
+** (contact: mail@dinusv.com)
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#ifndef LCVPHOTO_PLUGIN_H
+#define LCVPHOTO_PLUGIN_H
+
+#include <QQmlExtensionPlugin>
+
+class LcvphotoPlugin : public QQmlExtensionPlugin{
+
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QQmlExtensionInterface")
+
+public:
+    void registerTypes(const char *uri);
+};
+
+#endif // LCVPHOTO_PLUGIN_H
+

--- a/plugins/lcvphoto/src/qfastnlmeansdenoising.cpp
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoising.cpp
@@ -1,0 +1,77 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+#include "qfastnlmeansdenoising.h"
+#include "opencv2/photo/photo.hpp"
+
+using namespace cv;
+
+/*!
+  \qmltype FastNlMeansDenoising
+  \instantiates QFastNlMeansDenoising
+  \inqmlmodule lcvphoto
+  \inherits MatFilter
+  \brief Denoises a grayscale or color image.
+
+  Performs denoising using the Non-local Means Denoising algorithm.
+*/
+
+/*!
+  \class QFastNlMeansDenoising
+  \inmodule lcvphoto_cpp
+  \brief Finds edges within an image.
+ */
+
+/*!
+  \brief QFastNlMeansDenoising constructor
+
+  Parameters :
+  \a parent
+ */
+QFastNlMeansDenoising::QFastNlMeansDenoising(QQuickItem *parent) :
+    QMatFilter(parent),
+    m_useColorAlgorithm(false),
+    m_autoDetectColor(true),
+    m_h(3),
+    m_hColor(3),
+    m_templateWindowSize(7),
+    m_searchWindowSize(21){
+}
+
+/*!
+  \brief QFastNlMeansDenoising destructor
+ */
+QFastNlMeansDenoising::~QFastNlMeansDenoising(){
+}
+
+/*!
+  \brief Filter function.
+
+  Parameters:
+  \a in
+  \a out
+ */
+void QFastNlMeansDenoising::transform(cv::Mat &in, cv::Mat &out){
+    if ( !in.empty() ){ // fastNlMeansDenoising hangs on empty Mat
+        bool useColorAlgorithm = m_useColorAlgorithm;
+        if ( m_autoDetectColor ){
+            useColorAlgorithm = (in.channels() > 1);
+        }
+        if ( useColorAlgorithm ){
+            fastNlMeansDenoisingColored(in, out, m_h, m_hColor, m_templateWindowSize, m_searchWindowSize);
+        }
+        else{
+            fastNlMeansDenoising(in, out, m_h, m_templateWindowSize, m_searchWindowSize);
+        }
+    }
+}

--- a/plugins/lcvphoto/src/qfastnlmeansdenoising.cpp
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoising.cpp
@@ -55,6 +55,65 @@ QFastNlMeansDenoising::~QFastNlMeansDenoising(){
 }
 
 /*!
+  \property QFastNlMeansDenoising::colorAlgorithm
+  \sa FastNlMeansDenoising::colorAlgorithm
+ */
+
+/*!
+  \qmlproperty bool FastNlMeansDenoising::colorAlgorithm
+
+  False to use fastNlMeansDenoising, true to use fastNlMeansDenoisingColored.
+  By default, this is autodetected based on the number of channels in the source.
+ */
+
+/*!
+  \property QFastNlMeansDenoising::h
+  \sa FastNlMeansDenoising::h
+ */
+
+/*!
+  \qmlproperty float FastNlMeansDenoising::h
+
+  Parameter regulating filter strength. Defaults to 3.
+ */
+
+/*!
+  \property QFastNlMeansDenoising::hColor
+  \sa FastNlMeansDenoising::hColor
+ */
+
+/*!
+  \qmlproperty float FastNlMeansDenoising::hColor
+
+  The same as h but for color components. Defaults to 3.
+  Only relevant when using the color algorithm (see colorAlgorithm).
+ */
+
+/*!
+  \property QFastNlMeansDenoising::templateWindowSize
+  \sa FastNlMeansDenoising::templateWindowSize
+ */
+
+/*!
+  \qmlproperty int FastNlMeansDenoising::templateWindowSize
+
+  Size in pixels of the template patch that is used to compute weights.
+  Should be odd. Defaults to 7.
+ */
+
+/*!
+  \property QFastNlMeansDenoising::searchWindowSize
+  \sa FastNlMeansDenoising::searchWindowSize
+ */
+
+/*!
+  \qmlproperty int FastNlMeansDenoising::searchWindowSize
+
+  Size in pixels of the window that is used to compute weighted average for given pixel.
+  Has a large performance impact. Should be odd. Defaults to 21.
+ */
+
+/*!
   \brief Filter function.
 
   Parameters:

--- a/plugins/lcvphoto/src/qfastnlmeansdenoising.cpp
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoising.cpp
@@ -29,7 +29,7 @@ using namespace cv;
 /*!
   \class QFastNlMeansDenoising
   \inmodule lcvphoto_cpp
-  \brief Finds edges within an image.
+  \brief Performs denoising using the Non-local Means Denoising algorithm.
  */
 
 /*!
@@ -61,13 +61,13 @@ QFastNlMeansDenoising::~QFastNlMeansDenoising(){
   \a in
   \a out
  */
-void QFastNlMeansDenoising::transform(cv::Mat &in, cv::Mat &out){
+void QFastNlMeansDenoising::transform(Mat &in, Mat &out){
     if ( !in.empty() ){ // fastNlMeansDenoising hangs on empty Mat
-        bool useColorAlgorithm = m_useColorAlgorithm;
+        bool colorEnabled = m_useColorAlgorithm;
         if ( m_autoDetectColor ){
-            useColorAlgorithm = (in.channels() > 1);
+            colorEnabled = (in.channels() > 1);
         }
-        if ( useColorAlgorithm ){
+        if ( colorEnabled ){
             fastNlMeansDenoisingColored(in, out, m_h, m_hColor, m_templateWindowSize, m_searchWindowSize);
         }
         else{

--- a/plugins/lcvphoto/src/qfastnlmeansdenoising.cpp
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoising.cpp
@@ -24,6 +24,8 @@ using namespace cv;
   \brief Denoises a grayscale or color image.
 
   Performs denoising using the Non-local Means Denoising algorithm.
+
+  \quotefile photo/fastnlmeansdenoising.qml
 */
 
 /*!

--- a/plugins/lcvphoto/src/qfastnlmeansdenoising.h
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoising.h
@@ -50,6 +50,9 @@ signals:
     void templateWindowSizeChanged();
     void searchWindowSizeChanged();
 
+protected:
+    bool autoDetectColor() const;
+
 private:
     bool m_useColorAlgorithm;
     bool m_autoDetectColor;
@@ -61,6 +64,10 @@ private:
 
 inline bool QFastNlMeansDenoising::colorAlgorithm() const{
     return m_useColorAlgorithm;
+}
+
+inline bool QFastNlMeansDenoising::autoDetectColor() const{
+    return m_autoDetectColor;
 }
 
 inline float QFastNlMeansDenoising::h() const{

--- a/plugins/lcvphoto/src/qfastnlmeansdenoising.h
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoising.h
@@ -1,0 +1,120 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+#ifndef QFASTNLMEANSDENOISING_HPP
+#define QFASTNLMEANSDENOISING_HPP
+
+#include "qmatfilter.h"
+
+class QFastNlMeansDenoising : public QMatFilter{
+
+    Q_OBJECT
+    Q_PROPERTY(bool  colorAlgorithm     READ colorAlgorithm     WRITE setColorAlgorithm     NOTIFY colorAlgorithmChanged)
+    Q_PROPERTY(float h                  READ h                  WRITE setH                  NOTIFY hChanged)
+    Q_PROPERTY(float hColor             READ hColor             WRITE setHColor             NOTIFY hColorChanged)
+    Q_PROPERTY(int   templateWindowSize READ templateWindowSize WRITE setTemplateWindowSize NOTIFY templateWindowSizeChanged)
+    Q_PROPERTY(int   searchWindowSize   READ searchWindowSize   WRITE setSearchWindowSize   NOTIFY searchWindowSizeChanged)
+
+public:
+    explicit QFastNlMeansDenoising(QQuickItem *parent = 0);
+    ~QFastNlMeansDenoising();
+
+    virtual void transform(cv::Mat &in, cv::Mat &out);
+
+    bool colorAlgorithm() const;
+    float h() const;
+    float hColor() const;
+    int templateWindowSize() const;
+    int searchWindowSize() const;
+
+    void setColorAlgorithm(bool useColorAlgorithm);
+    void setH(float h);
+    void setHColor(float hColor);
+    void setTemplateWindowSize(int templateWindowSize);
+    void setSearchWindowSize(int searchWindowSize);
+
+signals:
+    void colorAlgorithmChanged();
+    void hChanged();
+    void hColorChanged();
+    void templateWindowSizeChanged();
+    void searchWindowSizeChanged();
+
+private:
+    bool m_useColorAlgorithm;
+    bool m_autoDetectColor;
+    float m_h;
+    float m_hColor;
+    int m_templateWindowSize;
+    int m_searchWindowSize;
+};
+
+inline bool QFastNlMeansDenoising::colorAlgorithm() const{
+    return m_useColorAlgorithm;
+}
+
+inline float QFastNlMeansDenoising::h() const{
+    return m_h;
+}
+
+inline float QFastNlMeansDenoising::hColor() const{
+    return m_hColor;
+}
+
+inline int QFastNlMeansDenoising::templateWindowSize() const{
+    return m_templateWindowSize;
+}
+
+inline int QFastNlMeansDenoising::searchWindowSize() const{
+    return m_searchWindowSize;
+}
+
+inline void QFastNlMeansDenoising::setColorAlgorithm(bool useColorAlgorithm){
+    m_autoDetectColor = false;
+    if ( m_useColorAlgorithm != useColorAlgorithm ){
+        m_useColorAlgorithm = useColorAlgorithm;
+        emit colorAlgorithmChanged();
+    }
+}
+
+inline void QFastNlMeansDenoising::setH(float h){
+    if ( m_h != h ){
+        m_h = h;
+        emit hChanged();
+    }
+}
+
+inline void QFastNlMeansDenoising::setHColor(float hColor){
+    if ( m_hColor != hColor ){
+        m_hColor = hColor;
+        emit hColorChanged();
+    }
+}
+
+inline void QFastNlMeansDenoising::setTemplateWindowSize(int templateWindowSize){
+    if ( m_templateWindowSize != templateWindowSize ){
+        m_templateWindowSize = templateWindowSize;
+        emit templateWindowSizeChanged();
+        QMatFilter::transform();
+    }
+}
+
+inline void QFastNlMeansDenoising::setSearchWindowSize(int searchWindowSize){
+    if ( m_searchWindowSize != searchWindowSize ){
+        m_searchWindowSize = searchWindowSize;
+        emit searchWindowSizeChanged();
+        QMatFilter::transform();
+    }
+}
+
+#endif // QFASTNLMEANSDENOISING_HPP

--- a/plugins/lcvphoto/src/qfastnlmeansdenoisingmulti.cpp
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoisingmulti.cpp
@@ -1,0 +1,97 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+#include "qfastnlmeansdenoisingmulti.h"
+#include "opencv2/photo/photo.hpp"
+
+using namespace cv;
+
+/*!
+  \qmltype FastNlMeansDenoisingMulti
+  \instantiates QFastNlMeansDenoisingMulti
+  \inqmlmodule lcvphoto
+  \inherits FastNlMeansDenoising
+  \brief Denoises a grayscale or color image using multiple frames.
+
+  Variant of FastNlMeansDenoising using a history of frames.
+*/
+
+/*!
+  \class QFastNlMeansDenoisingMulti
+  \inmodule lcvphoto_cpp
+  \brief Denoises a grayscale or color image using multiple frames.
+ */
+
+/*!
+  \brief QFastNlMeansDenoisingMulti constructor
+
+  Parameters :
+  \a parent
+ */
+QFastNlMeansDenoisingMulti::QFastNlMeansDenoisingMulti(QQuickItem *parent) :
+    QFastNlMeansDenoising(parent),
+    m_temporalWindowSize(3){
+}
+
+/*!
+  \brief QFastNlMeansDenoisingMulti destructor
+ */
+QFastNlMeansDenoisingMulti::~QFastNlMeansDenoisingMulti(){
+}
+
+void QFastNlMeansDenoisingMulti::setTemporalWindowSize(int temporalWindowSize){
+    if ( (temporalWindowSize & 1) == 0 )
+        --temporalWindowSize; // Must be odd
+    if ( temporalWindowSize < 1 )
+        temporalWindowSize = 1;
+    if ( m_temporalWindowSize != temporalWindowSize ){
+        m_frameHistory.reserve(temporalWindowSize);
+        trimFrameHistory(temporalWindowSize);
+        m_temporalWindowSize = temporalWindowSize;
+        emit temporalWindowSizeChanged();
+        QMatFilter::transform();
+    }
+}
+
+void QFastNlMeansDenoisingMulti::trimFrameHistory(std::size_t size){
+    if (m_frameHistory.size() > size){
+        int elementsToDelete = m_frameHistory.size() - size;
+        m_frameHistory.erase(m_frameHistory.begin(), m_frameHistory.begin() + elementsToDelete);
+    }
+}
+
+/*!
+  \brief Filter function.
+
+  Parameters:
+  \a in
+  \a out
+ */
+void QFastNlMeansDenoisingMulti::transform(Mat &in, Mat &out){
+    if ( !in.empty() ){ // fastNlMeansDenoising hangs on empty Mat
+        trimFrameHistory(temporalWindowSize() - 1);
+        m_frameHistory.push_back(in.clone());
+        if ( m_frameHistory.size() == static_cast<std::size_t>(temporalWindowSize()) ){
+            bool colorEnabled = colorAlgorithm();
+            if ( autoDetectColor() ){
+                colorEnabled = (in.channels() > 1);
+            }
+            if ( colorEnabled ){
+                fastNlMeansDenoisingColoredMulti(m_frameHistory, out, temporalWindowSize() / 2, temporalWindowSize(), h(), hColor(), templateWindowSize(), searchWindowSize());
+            }
+            else{
+                fastNlMeansDenoisingMulti(m_frameHistory, out, temporalWindowSize() / 2, temporalWindowSize(), h(), templateWindowSize(), searchWindowSize());
+            }
+        }
+    }
+}

--- a/plugins/lcvphoto/src/qfastnlmeansdenoisingmulti.cpp
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoisingmulti.cpp
@@ -32,7 +32,7 @@ using namespace cv;
   \list
   \li The algorithm is rather slow, which can be a problem for live video processing.
       Tweak the input framerate, searchWindowSize and temporalWindowSize as required.
-  \li The output will lag behind (temporalWindowSize-1)/2 frames behind the input.
+  \li The output will lag (temporalWindowSize-1)/2 frames behind the input.
   \li Output will only start when the buffer is filled; expect temporalWindowSize-1
       black output frames directly after recompiling the QML.
   \endlist

--- a/plugins/lcvphoto/src/qfastnlmeansdenoisingmulti.h
+++ b/plugins/lcvphoto/src/qfastnlmeansdenoisingmulti.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+#ifndef QFASTNLMEANSDENOISINGMULTI_HPP
+#define QFASTNLMEANSDENOISINGMULTI_HPP
+
+#include <QList>
+#include "qfastnlmeansdenoising.h"
+
+using namespace cv;
+
+class QFastNlMeansDenoisingMulti : public QFastNlMeansDenoising{
+
+    Q_OBJECT
+    Q_PROPERTY(int   temporalWindowSize READ temporalWindowSize WRITE setTemporalWindowSize NOTIFY temporalWindowSizeChanged)
+
+public:
+    explicit QFastNlMeansDenoisingMulti(QQuickItem *parent = 0);
+    ~QFastNlMeansDenoisingMulti();
+
+    virtual void transform(cv::Mat &in, cv::Mat &out);
+
+    int temporalWindowSize() const;
+
+    void setTemporalWindowSize(int temporalWindowSize);
+
+signals:
+    void temporalWindowSizeChanged();
+
+private:
+    void trimFrameHistory(std::size_t size);
+
+private:
+    int m_temporalWindowSize;
+    std::vector<Mat> m_frameHistory;
+};
+
+inline int QFastNlMeansDenoisingMulti::temporalWindowSize() const{
+    return m_temporalWindowSize;
+}
+
+#endif // QFASTNLMEANSDENOISINGMULTI_HPP

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -9,4 +9,4 @@ SUBDIRS += $$PWD/lcvcore
 SUBDIRS += $$PWD/lcvimgproc
 SUBDIRS += $$PWD/lcvvideo
 SUBDIRS += $$PWD/lcvfeatures2d
-
+SUBDIRS += $$PWD/lcvphoto

--- a/samples/photo/fastnlmeansdenoising.qml
+++ b/samples/photo/fastnlmeansdenoising.qml
@@ -1,0 +1,21 @@
+import lcvcore 1.0
+import lcvphoto 1.0
+
+Grid{
+    
+    // Usage of FastNlMeansDenoising
+    
+    columns: 2
+    
+    ImRead{
+       id : src
+       file : codeDocument.path + '/../_images/object_101_piano_query.jpg'
+    }
+    
+    FastNlMeansDenoising{
+        input : src.output
+        h : 10.0
+    }
+    
+}
+


### PR DESCRIPTION
This is a work in progress for a LiveCV plugin corresponding with the OpenCV [photo module](http://docs.opencv.org/2.4.13/modules/photo/doc/photo.html). Currently two of five methods (fastNlMeansDenoising and fastNlMeansDenoisingColored) are implemented, although the QDoc is not yet complete. Both are implemented as FastNlMeansDenoising, with a setting to use the non-color or color version. This is autodetected by default based on the number of channels, which is what you'd want unless you're doing advanced stuff with channels and color spaces, I believe.

I ran into an issue with the application hanging with 100% CPU usage when the FastNlMeansDenoising component was initialized without an input or together with the component providing its input. Turns out that the underlying OpenCV functions choke on the empty Mat that the transform() function is fed before there is any real input. Maybe you already knew this but if not, it's good to keep in mind that not all OpenCV functions can handle an empty matrix input.