### PR TITLE
Fix BackgroundSubtractor reset on recompile

### DIFF
--- a/plugins/lcvvideo/src/qbackgroundsubtractor.cpp
+++ b/plugins/lcvvideo/src/qbackgroundsubtractor.cpp
@@ -154,6 +154,6 @@ void QBackgroundSubtractor::setLearningRate(double rate){
 void QBackgroundSubtractor::transform(Mat& in, Mat& out){
     Q_D(QBackgroundSubtractor);
     BackgroundSubtractor* subtractor = d->subtractor();
-    if (subtractor)
+    if ( subtractor && !in.empty() )
         (*subtractor)(in, out, d->learningRate());
 }


### PR DESCRIPTION
Another issue with empty input matrices: I noticed that even though the StateContainer is used, the subtractor would reset on every recompile. Ignoring empty inputs resolves this.