### PR TITLE
Add BilateralFilter to lcvimgproc

### DIFF
--- a/plugins/lcvimgproc/src/lcvimgproc.pri
+++ b/plugins/lcvimgproc/src/lcvimgproc.pri
@@ -14,7 +14,8 @@ HEADERS += \
     $$PWD/qmatresize.h \
     $$PWD/qsobel.h \
     $$PWD/qstructuringelement.h \
-    $$PWD/qthreshold.h
+    $$PWD/qthreshold.h \
+    $$PWD/qbilateralfilter.h
 
 SOURCES += \
 	$$PWD/lcvimgproc_plugin.cpp \
@@ -32,5 +33,6 @@ SOURCES += \
     $$PWD/qmatresize.cpp \
     $$PWD/qsobel.cpp \
     $$PWD/qstructuringelement.cpp \
-    $$PWD/qthreshold.cpp
+    $$PWD/qthreshold.cpp \
+    $$PWD/qbilateralfilter.cpp
 

--- a/plugins/lcvimgproc/src/lcvimgproc_plugin.cpp
+++ b/plugins/lcvimgproc/src/lcvimgproc_plugin.cpp
@@ -32,6 +32,7 @@
 #include "qdilate.h"
 #include "qerode.h"
 #include "qcopymakeborder.h"
+#include "qbilateralfilter.h"
 
 void LcvimgprocPlugin::registerTypes(const char *uri){
     // @uri modules.lcvimgproc
@@ -50,6 +51,7 @@ void LcvimgprocPlugin::registerTypes(const char *uri){
     qmlRegisterType<QDilate>(             uri, 1, 0, "Dilate");
     qmlRegisterType<QErode>(              uri, 1, 0, "Erode");
     qmlRegisterType<QCopyMakeBorder>(     uri, 1, 0, "CopyMakeBorder");
+    qmlRegisterType<QBilateralFilter>(    uri, 1, 0, "BilateralFilter");
 }
 
 

--- a/plugins/lcvimgproc/src/qbilateralfilter.cpp
+++ b/plugins/lcvimgproc/src/qbilateralfilter.cpp
@@ -1,0 +1,183 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#include "qbilateralfilter.h"
+
+using namespace cv;
+
+/*!
+  \qmltype BilateralFilter
+  \instantiates QBilateralFilter
+  \inqmlmodule lcvimgproc
+  \inherits MatFilter
+  \brief Applies the bilateral filter to an image.
+
+  \quotefile imgproc/bilateralfilter.qml
+*/
+
+/*!
+   \class QBilateralFilter
+   \inmodule lcvimgproc_cpp
+   \brief Applies the bilateral filter to an image.
+ */
+
+class QBilateralFilterPrivate{
+
+public:
+    QBilateralFilterPrivate();
+    ~QBilateralFilterPrivate();
+
+public:
+    int dVal;
+    double sigmaColor;
+    double sigmaSpace;
+    int borderType;
+
+};
+
+// QBilateralFilterPrivate Implementation
+// --------------------------------------
+QBilateralFilterPrivate::QBilateralFilterPrivate() :
+    dVal(9),
+    sigmaColor(75),
+    sigmaSpace(75),
+    borderType(BORDER_DEFAULT){
+}
+
+QBilateralFilterPrivate::~QBilateralFilterPrivate(){
+}
+
+// QBilateralFilter Implementation
+// -------------------------------
+
+/*!
+  \brief QBilateralFilter constructor
+
+  Parameters:
+  \a parent
+ */
+QBilateralFilter::QBilateralFilter(QQuickItem *parent) :
+    QMatFilter(parent),
+    d_ptr(new QBilateralFilterPrivate){
+}
+
+/*!
+  \brief QBilateralFilter destructor
+ */
+QBilateralFilter::~QBilateralFilter(){
+}
+
+/*!
+  \property QBilateralFilter::d
+  \sa BilateralFilter::d
+ */
+
+/*!
+  \qmlproperty int BilateralFilter::d
+
+  Diameter of each pixel neighborhood that is used during filtering.
+ */
+int QBilateralFilter::d() const{
+    Q_D(const QBilateralFilter);
+    return d->dVal;
+}
+
+void QBilateralFilter::setD(int dVal){
+    Q_D(QBilateralFilter);
+    if ( d->dVal != dVal ){
+        d->dVal = dVal;
+        emit dChanged();
+    }
+}
+
+/*!
+  \property QBilateralFilter::sigmaColor
+  \sa BilateralFilter::sigmaColor
+ */
+
+/*!
+  \qmlproperty double BilateralFilter::sigmaColor
+
+  Filter sigma in the color space.
+ */
+double QBilateralFilter::sigmaColor() const{
+    Q_D(const QBilateralFilter);
+    return d->sigmaColor;
+}
+
+void QBilateralFilter::setSigmaColor(double sigmaColor){
+    Q_D(QBilateralFilter);
+    if ( d->sigmaColor != sigmaColor ){
+        d->sigmaColor = sigmaColor;
+        emit sigmaColorChanged();
+    }
+}
+
+/*!
+  \property QBilateralFilter::sigmaSpace
+  \sa BilateralFilter::sigmaSpace
+ */
+
+/*!
+  \qmlproperty double BilateralFilter::sigmaSpace
+
+  Filter sigma in the coordinate space.
+ */
+double QBilateralFilter::sigmaSpace() const{
+    Q_D(const QBilateralFilter);
+    return d->sigmaSpace;
+}
+
+void QBilateralFilter::setSigmaSpace(double sigmaSpace){
+    Q_D(QBilateralFilter);
+    if ( d->sigmaSpace != sigmaSpace ){
+        d->sigmaSpace = sigmaSpace;
+        emit sigmaSpaceChanged();
+    }
+}
+
+/*!
+  \property QBilateralFilter::borderType
+  \sa BilateralFilter::borderType
+ */
+
+/*!
+  \qmlproperty int BilateralFilter::borderType
+
+  Pixel extrapolation method.
+ */
+int QBilateralFilter::borderType() const{
+    Q_D(const QBilateralFilter);
+    return d->borderType;
+}
+
+void QBilateralFilter::setBorderType(int borderType){
+    Q_D(QBilateralFilter);
+    if ( d->borderType != borderType ){
+        d->borderType = borderType;
+        emit borderTypeChanged();
+    }
+}
+
+/*!
+  \brief Filter processing function.
+
+  Params:
+  \a in
+  \a out
+ */
+void QBilateralFilter::transform(Mat& in, Mat& out){
+    Q_D(const QBilateralFilter);
+    bilateralFilter(in, out, d->dVal, d->sigmaColor, d->sigmaSpace, d->borderType);
+}

--- a/plugins/lcvimgproc/src/qbilateralfilter.h
+++ b/plugins/lcvimgproc/src/qbilateralfilter.h
@@ -1,0 +1,65 @@
+/****************************************************************************
+**
+** This file is part of Live CV Application.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+****************************************************************************/
+
+#ifndef QBILATERALFILTER_HPP
+#define QBILATERALFILTER_HPP
+
+#include <QQuickItem>
+#include "qmatfilter.h"
+
+class QBilateralFilterPrivate;
+
+class QBilateralFilter : public QMatFilter{
+
+    Q_OBJECT
+    Q_PROPERTY(int    d          READ d          WRITE setD          NOTIFY dChanged)
+    Q_PROPERTY(double sigmaColor READ sigmaColor WRITE setSigmaColor NOTIFY sigmaColorChanged)
+    Q_PROPERTY(double sigmaSpace READ sigmaSpace WRITE setSigmaSpace NOTIFY sigmaSpaceChanged)
+    Q_PROPERTY(int    borderType READ borderType WRITE setBorderType NOTIFY borderTypeChanged)
+
+public:
+    explicit QBilateralFilter(QQuickItem *parent = 0);
+    ~QBilateralFilter();
+
+    int d() const;
+    void setD(int d);
+
+    double sigmaColor() const;
+    void setSigmaColor(double sigmaColor);
+
+    double sigmaSpace() const;
+    void setSigmaSpace(double sigmaSpace);
+
+    int borderType() const;
+    void setBorderType(int borderType);
+
+    virtual void transform(cv::Mat& in, cv::Mat& out);
+
+signals:
+    void dChanged();
+    void sigmaColorChanged();
+    void sigmaSpaceChanged();
+    void borderTypeChanged();
+
+private:
+    QBilateralFilter(const QBilateralFilter& other);
+    QBilateralFilter& operator= (const QBilateralFilter& other);
+
+    QBilateralFilterPrivate* const d_ptr;
+
+    Q_DECLARE_PRIVATE(QBilateralFilter)
+
+};
+
+#endif // QBILATERALFILTER_HPP

--- a/samples/imgproc/bilateralfilter.qml
+++ b/samples/imgproc/bilateralfilter.qml
@@ -1,0 +1,19 @@
+import lcvcore 1.0
+import lcvimgproc 1.0
+
+Row{
+  
+    CamCapture{
+        id : cam
+        device : '0'
+    }
+
+    BilateralFilter{
+        input : cam.output
+        d : 9
+        sigmaColor : 100
+        sigmaSpace : 100
+    }
+   
+}
+


### PR DESCRIPTION
Pretty straightforward. This filter can be an alternative for denoising that is less processing intensive than the methods from lcvphoto, but sacrifices some image sharpness (but not as much as, say, a Gaussian blur). 