### PR TITLE
Create missing samples for lcvimgproc elements

### DIFF
--- a/plugins/lcvimgproc/src/qcopymakeborder.cpp
+++ b/plugins/lcvimgproc/src/qcopymakeborder.cpp
@@ -27,7 +27,7 @@ using namespace cv;
 
   The areas to the left, to the right, above and below the copied source image will be filled with extrapolated pixels
 
-  \quotefile imgproc/blur.qml
+  \quotefile imgproc/copymakeborder.qml
 */
 
 /*!

--- a/plugins/lcvimgproc/src/qcvtcolor.cpp
+++ b/plugins/lcvimgproc/src/qcvtcolor.cpp
@@ -25,7 +25,7 @@ using namespace cv;
   \inherits MatFilter
   \brief Converts an image from one color space to another.
 
-  \quotefile imgproc/blur.qml
+  \quotefile imgproc/threshold.qml
 */
 
 /*!

--- a/plugins/lcvimgproc/src/qthreshold.cpp
+++ b/plugins/lcvimgproc/src/qthreshold.cpp
@@ -27,7 +27,7 @@
   bi-level (binary) image out of a grayscale image ( compare() could be also used for this purpose) or for removing a
   noise, that is, filtering out pixels with too small or too large values.
 
-  \quotefile imgproc/canny.qml
+  \quotefile imgproc/threshold.qml
 */
 
 /*!

--- a/samples/imgproc/copymakeborder.qml
+++ b/samples/imgproc/copymakeborder.qml
@@ -1,0 +1,22 @@
+import lcvcore 1.0
+import lcvimgproc 1.0
+
+Row{
+
+    // This sample shows the usage of the CopyMakeBorder element
+
+    ImRead{
+       id : src
+       file : codeDocument.path + '/../_images/buildings_0246.jpg'
+    }
+
+    CopyMakeBorder{
+        input : src.output
+        borderType : CopyMakeBorder.BORDER_CONSTANT
+        color : "steelblue"
+        top : 10
+        bottom : 10
+        left : 10
+        right : 10
+    }
+}

--- a/samples/imgproc/threshold.qml
+++ b/samples/imgproc/threshold.qml
@@ -1,0 +1,28 @@
+import lcvcore 1.0
+import lcvimgproc 1.0
+
+Grid{
+    columns: 2
+
+    // This sample shows the usage of the CvtColor and Threshold
+    // elements
+
+    ImRead{
+       id : src
+       file : codeDocument.path + '/../_images/buildings_0246.jpg'
+    }
+
+    CvtColor{
+        id : grayscale
+        input : src.output
+        code : CvtColor.CV_BGR2GRAY
+        dstCn : 1
+    }
+
+    Threshold{
+        input: grayscale.output
+        thresh : 95
+        maxVal : 255
+        thresholdType : Threshold.BINARY
+    }
+}


### PR DESCRIPTION
Some people I recommended LiveCV to were confused by some important imgproc elements having unrelated samples on their documentation page, so I checked all imgproc elements and made samples for the three elements that didn't have a relevant sample.