### PR TITLE
Fixed oversight when removing config_paths.pri

### DIFF
--- a/plugins/lcvcore/lcvcore.pro
+++ b/plugins/lcvcore/lcvcore.pro
@@ -34,7 +34,7 @@ OTHER_FILES *= \
 
 # Deploy the palettes
 
-palettecopy.commands = $$deployDirCommand($$PWD/palettes, $$PATH_DEPLOY_PLUGINS/$$PLUGIN_NAME/palettes)
+palettecopy.commands = $$deployDirCommand($$PWD/palettes, $$DEPLOY_PATH/plugins/$$PLUGIN_NAME/palettes)
 first.depends = $(first) palettecopy
 export(first.depends)
 export(palettecopy.commands)

--- a/plugins/live/live.pro
+++ b/plugins/live/live.pro
@@ -27,7 +27,7 @@ OTHER_FILES *= \
 
 # Deploy The palette
 
-palettecopy.commands = $$deployDirCommand($$PWD/palettes, $$PATH_DEPLOY_PLUGINS/$$PLUGIN_NAME/palettes)
+palettecopy.commands = $$deployDirCommand($$PWD/palettes, $$DEPLOY_PATH/plugins/$$PLUGIN_NAME/palettes)
 first.depends = $(first) palettecopy
 export(first.depends)
 export(palettecopy.commands)

--- a/project/functions.pri
+++ b/project/functions.pri
@@ -105,7 +105,7 @@ defineTest(linkLocalLibrary){
 defineTest(linkLocalPlugin){
 
     win32:LIB_PATH = $$DEPLOY_PATH/dev/lib/plugins/$$1
-    else:LIB_PATH = $$PATH_DEPLOY_PLUGINS/$$1
+    else:LIB_PATH = $$DEPLOY_PATH/plugins/$$1
 
     LIB_NAME = $$2
     LIB_INCLUDE_PATH = $$PROJECT_ROOT/plugins/$$1/src


### PR DESCRIPTION
When removing the config_paths.pri, not all variables declared there were
replaced accordingly, leading to build errors on linux systems.
This has been addressed by inserting a suitable replacement.